### PR TITLE
Add default frontend API base configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,10 @@ Each bundle’s cost ledger tracks stays, intercity transport, food, activities,
 and remaining misc headroom so you can compare the spend against the requested
 budget at a glance.
 
-> **Tip:** The React frontend under `trip_planner_frontend/` targets
-> `http://localhost:8000/api/plan` by default. Set
-> `VITE_API_BASE_URL=http://localhost:8000` in
-> `trip_planner_frontend/.env.local` while the FastAPI server is running to
-> see live orchestration output instead of the bundled sample itinerary.
+> **Tip:** The React frontend under `trip_planner_frontend/` ships with
+> `.env.development` pointing to `http://localhost:8000/api/plan`. Start the
+> FastAPI server and run `npm run dev` to see live orchestration output. Create
+> `trip_planner_frontend/.env.local` if you need to target a different base URL.
 
 If you need to restrict browser origins, configure
 `TRIP_PLANNER_ALLOWED_ORIGINS` (comma-separated list). The default `*` keeps

--- a/trip_planner_frontend/.env.development
+++ b/trip_planner_frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/trip_planner_frontend/README.md
+++ b/trip_planner_frontend/README.md
@@ -14,12 +14,14 @@ The development server defaults to `http://localhost:5173`.
 
 ### Connecting to the orchestrator API
 
-Set the backend endpoint that exposes `POST /api/plan` using a Vite environment variable:
+Set the backend endpoint that exposes `POST /api/plan` using a Vite environment variable. A development preset is committed so the UI automatically targets the local FastAPI server:
 
 ```bash
-# .env.local
+# trip_planner_frontend/.env.development
 VITE_API_BASE_URL=http://localhost:8000
 ```
+
+You can override this by creating `.env.local` with the desired URL when pointing the frontend at a different orchestrator deployment.
 
 When the value is missing or the request fails, the app falls back to an interactive sample itinerary so the interface stays explorable offline.
 


### PR DESCRIPTION
## Summary
- add a committed Vite development environment file that points to the FastAPI orchestrator on localhost
- document the default API base URL in both the frontend and repository READMEs and explain how to override it

## Testing
- uv run pytest *(fails: unable to download pytest-asyncio because the execution environment blocks network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cc31774dcc8323aa4bb5af979a14d5