### PR TITLE
Improve destination scout landmark heuristics

### DIFF
--- a/tests/test_destination_scout.py
+++ b/tests/test_destination_scout.py
@@ -1,0 +1,18 @@
+"""Regression tests for destination scouting heuristics."""
+
+from app.agents.destination_scout import _extract_points
+
+
+def test_extract_points_retains_dont_miss_landmark():
+    snippet = "Don't miss Disneyland Paris for a day of magic with the family."
+    highlights, dining = _extract_points(snippet, "Paris")
+
+    assert snippet in highlights
+    assert dining == []
+
+
+def test_extract_points_accepts_landmark_without_city_when_action_present():
+    snippet = "Don't miss the sweeping views from Table Mountain at sunset."
+    highlights, _ = _extract_points(snippet, "Cape Town")
+
+    assert snippet in highlights


### PR DESCRIPTION
## Summary
- expand destination scout action and point-of-interest heuristics so landmark-heavy snippets with travel phrasing are kept
- add regression coverage to ensure "Don't miss" style highlights remain emitted

## Testing
- `uv run pytest` *(fails: unable to fetch dependencies from pypi.org due to network error)*
- `pytest` *(fails: missing optional dependencies such as requests, fastapi, pydantic, httpx in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce70ebd8f083239a0e71d0b60be013